### PR TITLE
plantEasily: add bulk harvest hover text

### DIFF
--- a/Advize_PlantEasily/Advize_PlantEasily.csproj
+++ b/Advize_PlantEasily/Advize_PlantEasily.csproj
@@ -55,6 +55,10 @@
       <HintPath>$(GamePath)\BepInEx\core\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="assembly_guiutils">
+      <HintPath>$(GamePath)\valheim_Data\Managed\assembly_guiutils_publicized.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="assembly_utils">
       <HintPath>$(GamePath)\valheim_Data\Managed\assembly_utils.dll</HintPath>
       <Private>False</Private>
@@ -75,6 +79,10 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="Unity.InputSystem">
+      <HintPath>$(GamePath)\valheim_Data\Managed\Unity.InputSystem.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Unity.TextMeshPro">
       <HintPath>$(GamePath)\valheim_Data\Managed\Unity.TextMeshPro.dll</HintPath>
       <Private>False</Private>

--- a/Advize_PlantEasily/Extensions/KeyCode.cs
+++ b/Advize_PlantEasily/Extensions/KeyCode.cs
@@ -1,0 +1,50 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.LowLevel;
+
+namespace Advize_PlantEasily;
+
+public static class KeyCodeExtensions
+{
+  /// <summary>
+  /// Utility extension method mimicking Valheim's internal behaviour for localizing keycodes. The original logic can be
+  /// found in <c>ZInput.GetBoundKeyString(...)</c>, unfortunately it is intended for use with <c>ZInput.ButtonDef</c>
+  /// button names and dispatches the underlying keycodes right away in the same function, hence why we had to duplicate
+  /// the code.
+  /// </summary>
+  public static string ToLocalizableString(this KeyCode keyCode)
+  {
+    var (isMouseButton, mouseButton) = ZInput.KeyCodeToMouseButton(keyCode, logWarning: false);
+    if (isMouseButton)
+    {
+      var mouseString = mouseButton switch
+      {
+        MouseButton.Left => "$button_mouse0",
+        MouseButton.Right => "$button_mouse1",
+        MouseButton.Middle => "$button_mouse2",
+        MouseButton.Forward => Mouse.current?.forwardButton.displayName ?? "Mouse Forward",
+        MouseButton.Back => Mouse.current?.backButton.displayName ?? "Mouse Back",
+        _ => null,
+      };
+      if (mouseString is not null) return mouseString;
+    }
+
+    var key = ZInput.KeyCodeToKey(keyCode, logWarning: false);
+    return key switch
+    {
+      Key.Comma => ",",
+      Key.Period => ".",
+      Key.Space => "$button_space",
+      Key.LeftShift => "$button_lshift",
+      Key.RightShift => "$button_rshift",
+      Key.LeftAlt => "$button_lalt",
+      Key.RightAlt => "$button_ralt",
+      Key.LeftCtrl => "$button_lctrl",
+      Key.RightCtrl => "$button_rctrl",
+      Key.Enter => "$button_return",
+      Key.NumpadEnter => "$button_return",
+      Key.None => "$menu_none",
+      _ => Keyboard.current?[key].displayName ?? key.ToString(),
+    };
+  }
+}

--- a/Advize_PlantEasily/Patches/InteractPatches.cs
+++ b/Advize_PlantEasily/Patches/InteractPatches.cs
@@ -56,4 +56,30 @@ static class InteractPatches
         PlacePiece(player, __instance.gameObject, piece);
         player.ConsumeResources(piece.m_resources, 0);
     }
+
+    [HarmonyPatch(typeof(Beehive), nameof(Beehive.GetHoverText))]
+    static void Postfix(Beehive __instance, ref string __result)
+    {
+        if (!config.EnableBulkHarvest) return;
+
+        // only add our hover text if honey can actually be extracted
+        var isPrivate = !PrivateArea.CheckAccess(__instance.transform.position, 0f, flash: false);
+        var hasHoney = __instance.GetHoneyLevel() > 0;
+        if (isPrivate || !hasHoney) return;
+
+        var hoverTextSuffix = $"\n[<b><color=yellow>{config.KeyboardHarvestModifierKey.ToLocalizableString()}</color> + <color=yellow>$KEY_Use</color></b>] {__instance.m_extractText} (area)";
+        __result += Localization.instance.Localize(hoverTextSuffix);
+    }
+
+    [HarmonyPatch(typeof(Pickable), nameof(Pickable.GetHoverText))]
+    static void Postfix(Pickable __instance, ref string __result)
+    {
+        if (!config.EnableBulkHarvest) return;
+
+        // only add our hover text if the pickable can actually be picked
+        if (__instance.GetPicked() || __instance.GetEnabled == 0) return;
+
+        var hoverTextSuffix = $"\n[<b><color=yellow>{config.KeyboardHarvestModifierKey.ToLocalizableString()}</color> + <color=yellow>$KEY_Use</color></b>] $inventory_pickup (area)";
+        __result += Localization.instance.Localize(hoverTextSuffix);
+    }
 }


### PR DESCRIPTION
We add hover text to Pickable and Beehive objects to advertise the bulk harvest functionality to users, along with the hotkey to use.