### PR TITLE
Allow the Vanilla Alt Place Key to Disable Crop Snapping While Held.

### DIFF
--- a/Advize_PlantEasily/Configuration/ModConfig.cs
+++ b/Advize_PlantEasily/Configuration/ModConfig.cs
@@ -37,6 +37,7 @@ sealed class ModConfig
     private readonly ConfigEntry<bool> randomizeRotation;
     private readonly ConfigEntry<bool> enableDebugMessages;
 
+
     //Grid
     private readonly ConfigEntry<bool> globallyAlignGridDirections;
     private readonly ConfigEntry<bool> minimizeGridSpacing;
@@ -261,7 +262,7 @@ sealed class ModConfig
     }
     internal bool SnapActive
     {
-        get { return snapActive.Value; }
+        get { return snapActive.Value && !ZInput.GetButton("AltPlace"); }
         set { snapActive.BoxedValue = value; }
     }
     internal int Rows


### PR DESCRIPTION
Allows for disabling snapping of crops whenever the Vanilla `AltPlace` key is held (default Vanilla keybind is `LeftShift`) by checking for whether the key is held as part of the `config.SnapActive` property getter.